### PR TITLE
Optimize test loading

### DIFF
--- a/UnityEditor.TestRunner/TestRunner/Utils/EditorLoadedTestAssemblyProvider.cs
+++ b/UnityEditor.TestRunner/TestRunner/Utils/EditorLoadedTestAssemblyProvider.cs
@@ -69,50 +69,40 @@ namespace UnityEditor.TestTools.TestRunner
 
         private IAssemblyWrapper[] FilterAssembliesWithTestReference(IAssemblyWrapper[] loadedAssemblies)
         {
-            var filteredResults = new Dictionary<IAssemblyWrapper, bool>();
-            foreach (var assembly in loadedAssemblies)
-            {
-                FilterAssemblyForTestReference(assembly, loadedAssemblies, filteredResults, new Dictionary<IAssemblyWrapper, bool>());
-            }
-
-            return filteredResults.Where(pair => pair.Value).Select(pair => pair.Key).ToArray();
+            var resultsCache = new Dictionary<IAssemblyWrapper, bool>();
+            var loadedAssembliesDict = loadedAssemblies.ToDictionary(asm => asm.Name.Name, asm => asm);
+            return loadedAssemblies
+	            .Where(assembly => FilterAssemblyForTestReference(assembly, loadedAssembliesDict, resultsCache))
+	            .ToArray();
         }
 
-        private void FilterAssemblyForTestReference(IAssemblyWrapper assemblyToFilter, IAssemblyWrapper[] loadedAssemblies,
-            IDictionary<IAssemblyWrapper, bool> filterResults, IDictionary<IAssemblyWrapper, bool> resultsAlreadyAnalyzed)
+        // This method can easily become a performance bottleneck in big projects,
+        // so it needs to stay optimized in terms of computational complexity.
+        // This is why we use heavy caching of results and early returns
+        // as much as possible.
+        private bool FilterAssemblyForTestReference(
+            IAssemblyWrapper assemblyToFilter,
+            IReadOnlyDictionary<string, IAssemblyWrapper> loadedAssemblies,
+            IDictionary<IAssemblyWrapper, bool> resultsCache)
         {
-            if(resultsAlreadyAnalyzed.ContainsKey(assemblyToFilter))
+            if (resultsCache.TryGetValue(assemblyToFilter, out var existingResult))
             {
-                return;
+                return existingResult;
             }
 
-            resultsAlreadyAnalyzed[assemblyToFilter] = true;
-
-            var references = assemblyToFilter.GetReferencedAssemblies();
-            if (references.Any(IsTestReference))
+            foreach (var reference in assemblyToFilter.GetReferencedAssemblies())
             {
-                filterResults[assemblyToFilter] = true;
-                return;
+                if (IsTestReference(reference) ||
+	                (loadedAssemblies.TryGetValue(reference.Name, out var referencedAssembly) &&
+	                FilterAssemblyForTestReference(referencedAssembly, loadedAssemblies, resultsCache)))
+                 {
+	                resultsCache[assemblyToFilter] = true;
+	                return true;
+                 }
             }
 
-            foreach (var reference in references)
-            {
-                var referencedAssembly = loadedAssemblies.FirstOrDefault(a => a.Name.Name == reference.Name);
-                if (referencedAssembly == null)
-                {
-                    continue;
-                }
-
-                FilterAssemblyForTestReference(referencedAssembly, loadedAssemblies, filterResults, resultsAlreadyAnalyzed);
-
-                if (filterResults.ContainsKey(referencedAssembly) && filterResults[referencedAssembly])
-                {
-                    filterResults[assemblyToFilter] = true;
-                    return;
-                }
-            }
-
-            filterResults[assemblyToFilter] = false;
+            resultsCache[assemblyToFilter] = false;
+            return false;
         }
 
         private static bool IsTestReference(AssemblyName assemblyName)

--- a/UnityEngine.TestRunner/NUnitExtensions/Commands/EnumerableApplyChangesToContextCommand.cs.meta
+++ b/UnityEngine.TestRunner/NUnitExtensions/Commands/EnumerableApplyChangesToContextCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b4429eff9fcffb48b006e8edcc90338
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityEngine.TestRunner/NUnitExtensions/UnityTestAssemblyBuilder.cs
+++ b/UnityEngine.TestRunner/NUnitExtensions/UnityTestAssemblyBuilder.cs
@@ -65,6 +65,8 @@ namespace UnityEngine.TestTools.NUnitExtensions
         {
             var productName = string.Join("_", m_ProductName.Split(Path.GetInvalidFileNameChars()));
             var suite = new TestSuite(productName);
+
+            var lastYieldTime = Time.realtimeSinceStartup;
             for (var index = 0; index < assemblies.Length; index++)
             {
                 var assembly = assemblies[index];
@@ -90,7 +92,12 @@ namespace UnityEngine.TestTools.NUnitExtensions
                     }
                 }
 
-                yield return null;
+                // Yield a frame only if we've spent 10 ms or more here
+                if (Time.realtimeSinceStartup > lastYieldTime + 0.01f)
+                {
+                    yield return null;
+                    lastYieldTime = Time.realtimeSinceStartup;
+                }
             }
 
             suite.ParseForNameDuplicates();

--- a/UnityEngine.TestRunner/NUnitExtensions/UnityTestAssemblyBuilder.cs
+++ b/UnityEngine.TestRunner/NUnitExtensions/UnityTestAssemblyBuilder.cs
@@ -66,7 +66,7 @@ namespace UnityEngine.TestTools.NUnitExtensions
             var productName = string.Join("_", m_ProductName.Split(Path.GetInvalidFileNameChars()));
             var suite = new TestSuite(productName);
 
-            var lastYieldTime = Time.realtimeSinceStartup;
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
             for (var index = 0; index < assemblies.Length; index++)
             {
                 var assembly = assemblies[index];
@@ -93,10 +93,10 @@ namespace UnityEngine.TestTools.NUnitExtensions
                 }
 
                 // Yield a frame only if we've spent 10 ms or more here
-                if (Time.realtimeSinceStartup > lastYieldTime + 0.01f)
+                if (stopwatch.ElapsedMilliseconds >= 10)
                 {
                     yield return null;
-                    lastYieldTime = Time.realtimeSinceStartup;
+                    stopwatch.Restart();
                 }
             }
 


### PR DESCRIPTION
* Use the right data structure (Dictionary) to significantly speed up test assembly loading when lots of assemblies are used.
* If the assembly loads fast, keep loading more assemblies within the same frame, instead of yielding a frame after every assembly.